### PR TITLE
Add seaborn dependency

### DIFF
--- a/zents-dashboard - backup - Copia/requirements.txt
+++ b/zents-dashboard - backup - Copia/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 pandas
 plotly
 matplotlib
+seaborn


### PR DESCRIPTION
## Summary
- add `seaborn` to the requirements file

## Testing
- `pip install -r "zents-dashboard - backup - Copia/requirements.txt"` *(fails: Could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_684e49d22588832eb2af1388aec55020